### PR TITLE
CMakeLists.txt: append to CMAKE_C_FLAGS rather then overwriting it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.4)
 project(msnake)
 
-set(CMAKE_C_FLAGS "-Wall")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 
 set(CURSES_NEED_NCURSES TRUE)
 find_package(Curses)


### PR DESCRIPTION
As we wanted to use msnake for an small yocto exercise we need to be able to cross compile it. The current variant of just setting `CMAKE_C_FLAGS` breaks the env for cross compilation.
